### PR TITLE
Add support for Vi/Vim

### DIFF
--- a/dist/vim/a11y-dark.vim
+++ b/dist/vim/a11y-dark.vim
@@ -1,0 +1,225 @@
+" Name:        a11y-dark
+" Author:      original author Reuben L. Lillie <@reubenlillie>
+" DerivedFrom: https://www.github.com/vim/colorschemes 
+
+" Table 1. Theme colors with Xterm (X11) and ANSI approximations
+" ------------------------------------------------------------------------
+"  №  ANSI         HEX     Name              X11 №  X11 HEX   X11 Name
+" ------------------------------------------------------------------------
+"  0  Black        #2b2b2b Mine Shaft        235    #262626   Grey15
+"  7  LightGray    #d4d0ab Chino             187    #d7d7af   LightYellow3
+"  9  Red          #ffa07a Vivid Tangerine   209    #ff875f   Salmon1
+" 10  Green        #abe338 Conifer           118    #87ff00   Chartreuse1
+" 11  Yellow       #ffd700 Gold              220    #ffd700   Gold1
+" 13  Magenta      #dcc6e0 Snuff             219    #ffafff   Plum1
+" 14  Cyan         #00e0e0 Bright Turquoise   45    #00d7ff   Turquoise2 
+" 15  White        #f8f8f2 Spring Wood       255    #eeeeee   Grey93
+" ------------------------------------------------------------------------
+
+" ========================
+" §1. Prepare color scheme
+" ========================
+
+set background=dark
+highlight clear
+if exists("syntax_on")
+  syntax reset
+endif
+let g:colors_name="a11y-dark"
+let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ?? 0) : -1
+
+" =====================================================================
+" §2. Override default syntax highlighting links for specific languages
+" =====================================================================
+
+" Link the following highlight groups to the basic groups defined in §3.
+
+" ------------------------------
+" §2.1. HTML, Markdown, and YAML
+" ------------------------------
+
+" White
+hi! link htmlTag Normal
+hi! link markdownYamlHead Normal
+hi! link yamlDocumentStart Normal
+hi! link yamlFlowIndicator Normal
+hi! link yamlKeyValueDelimiter Normal
+" Green
+hi! link markdownCodeBlock Type
+hi! link markdownCodeDelimiter Type
+hi! link yamlFlowString Type
+" Yellow
+hi! link yamlBlockMappingKey Constant
+" Cyan
+hi! link markdownH1 Identifier
+hi! link markdownH1Delimiter Identifier
+hi! link markdownH2 Identifier
+hi! link markdownH2Delimiter Identifier
+hi! link markdownH3 Identifier
+hi! link markdownH3Delimiter Identifier
+hi! link markdownH4 Identifier
+hi! link markdownH4Delimiter Identifier
+hi! link markdownH5 Identifier
+hi! link markdownH5Delimiter Identifier
+hi! link markdownH6 Identifier
+hi! link markdownH6Delimiter Identifier
+" Magenta
+hi! link htmlSpecialChar Special
+
+" ---------
+" §2.2. CSS
+" ---------
+
+" Gray
+hi! link cssBraces Comment
+
+" ----------------
+" §2.3. JavaScript
+" ----------------
+
+" LightGray
+hi! link javaScriptBraces Comment
+hi! link javaScriptEmbed Comment
+hi! link javaScriptParens Comment
+" Red
+hi! link javaScriptConstant Statement
+" Green
+hi! link javaScriptSpecial Type
+hi! link javaScriptStringS Type
+hi! link javaScriptStringT Type
+" Yellow
+hi! link javaScriptConditional Constant
+hi! link javaScriptLabel Constant
+hi! link javaScriptMember Constant
+hi! link javaScriptStatement Constant
+" Magenta
+hi! link javaScriptNull PreProc
+" Cyan
+hi! link javaScriptNumber Identifier
+hi! link javaScriptOperator Identifier
+hi! link javaScriptReserved Identifier
+
+" ------------------------------
+" §2.4 Link Vim highlight groups
+" ------------------------------
+
+" LightGray
+hi! link EndOfBuffer Comment
+" Yellow
+hi! link LineNr Constant
+hi! link NonText Constant
+" Magenta
+hi! link PreProc Special
+" Cyan
+hi! link CursorLineNr Identifier
+" Other highlight groups
+hi! link ColorColumn Visual
+hi! link CurSearch Search
+hi! link Folded Ignore
+hi! link MatchParen Visual
+hi! link Pmenu Ignore
+hi! link PmenuSel Search
+hi! link SpellBad ErrorMsg
+hi! link TabLine Ignore
+hi! link WildMenu Search
+hi! link vimHiKeyError ErrorMsg
+
+" ========================================================
+" §3. Set basic color scheme for different editions of Vim
+" ========================================================
+
+" --------------------------
+" §3.1 gVim highlight groups
+" --------------------------
+
+" Define an array of hexadecimal codes to override the 16 basic ANSI colors.
+if (has('termguicolors') && &termguicolors) || has('gui_running')
+  let g:terminal_ansi_colors = ['#2b2b2b', '#ffa07a', '#abe338', '#d4d0ab', '#00e0e0', '#dcc6e0', '#00e0e0', '#d4d0ab', '#d4d0ab', '#ffa07a', '#abe338', '#ffd700', '#00e0e0', '#dcc6e0', '#00e0e0', '#f8f8f2']
+endif
+
+" LightGray
+hi Comment guifg=#d4d0ab guibg=#2b2b2b gui=NONE
+" Red
+hi Statement guifg=#ffa07a guibg=#2b2b2b gui=NONE
+" Green
+hi Type guifg=#abe338 guibg=#2b2b2b gui=NONE
+" Yellow
+hi Constant guifg=#ffd700 guibg=#2b2b2b gui=NONE
+" Magenta
+hi Special guifg=#dcc6e0 guibg=#2b2b2b gui=NONE
+" Cyan
+hi Identifier guifg=#00e0e0 guibg=#2b2b2b gui=NONE
+" White
+hi Normal guifg=#f8f8f2 guibg=#2b2b2b gui=NONE
+" Other highlight groups
+hi ErrorMsg guifg=#2b2b2b guibg=#ffa07a gui=bold
+hi Ignore guifg=#2b2b2b guibg=#d4d0ab gui=NONE
+hi Search guifg=#2b2b2b guibg=#ffd700 gui=bold
+hi Title guifg=NONE guibg=NONE gui=bold
+hi Todo guifg=#2b2b2b guibg=#abe338 gui=bold
+hi Underlined guifg=NONE guibg=NONE gui=underline
+hi Visual guifg=NONE guibg=NONE gui=reverse
+
+" -------------------------------------------------------
+" §3.2. Vim highlight groups for 256-color Xterm consoles
+" -------------------------------------------------------
+
+" Xterm colors are available to most modern terminal emulators.
+if s:t_Co >= 256
+  " LightGray
+  hi Comment ctermfg=187 ctermbg=235 cterm=NONE
+  " Red
+  hi Statement ctermfg=209 ctermbg=235 cterm=NONE
+  " Green
+  hi Type ctermfg=118 ctermbg=235 cterm=NONE
+  " Yellow
+  hi Constant ctermfg=220 ctermbg=235 cterm=NONE
+  " Magenta
+  hi Special ctermfg=219 ctermbg=235 cterm=NONE
+  " Cyan
+  hi Identifier ctermfg=45 ctermbg=235 cterm=NONE
+  " White
+  hi Normal ctermfg=255 ctermbg=235 cterm=NONE
+  " Other highlight groups
+  hi ErrorMsg ctermfg=235 ctermbg=209 cterm=bold
+  hi Ignore ctermfg=235 ctermbg=187 cterm=NONE
+  hi Search ctermfg=235 ctermbg=220 cterm=bold
+  hi Title ctermfg=NONE ctermbg=NONE cterm=bold
+  hi Todo ctermfg=235 ctermbg=118 cterm=bold
+  hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline
+  hi Visual ctermfg=NONE ctermbg=NONE cterm=reverse
+  unlet s:t_Co
+  finish
+endif
+
+" -----------------------------------------------------
+" §3.3. Vim highlight groups for 16-color ANSI consoles
+" -----------------------------------------------------
+
+" ANSI colors are available to most legacy terminal emulators.
+if s:t_Co >= 16
+  " LightGray
+  hi Comment ctermfg=LightGray ctermbg=Black cterm=NONE
+  " Red
+  hi Statement ctermfg=Red ctermbg=Black cterm=NONE
+  " Green
+  hi Type ctermfg=Green ctermbg=Black cterm=NONE
+  " Yellow
+  hi Constant ctermfg=Yellow ctermbg=Black cterm=NONE
+  " Magenta
+  hi Special ctermfg=Magenta ctermbg=Black cterm=NONE
+  " Cyan
+  hi Identifier ctermfg=Cyan ctermbg=Black cterm=NONE
+  " White
+  hi Normal ctermfg=White ctermbg=Black  cterm=NONE
+  " Other highlight groups
+  hi ErrorMsg ctermfg=Black ctermbg=Red cterm=bold
+  hi Ignore cterm=NONE ctermfg=Black ctermbg=LightGray
+  hi Search ctermfg=Black ctermbg=Yellow cterm=bold
+  hi Title ctermfg=NONE ctermbg=NONE cterm=bold
+  hi Todo ctermfg=Black ctermbg=Green cterm=bold
+  hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline
+  hi Visual ctermfg=NONE ctermbg=NONE cterm=reverse
+  unlet s:t_Co
+  finish
+endif

--- a/dist/vim/a11y-light.vim
+++ b/dist/vim/a11y-light.vim
@@ -1,0 +1,203 @@
+" Name:        a11y-light
+" Author:      original author Reuben L. Lillie <@reubenlillie>
+" DerivedFrom: https://www.github.com/vim/colorschemes 
+
+" Table 1. Theme colors with Xterm (X11) and ANSI approximations
+" ------------------------------------------------------------------------
+"  №  ANSI         HEX     Name              X11 №  X11 HEX   X11 Name
+" ------------------------------------------------------------------------
+"  0  Black        #545454 Emperor           240    #585858   Grey35
+"  3  Brown        #aa5d00 Chelsea Gem       130    #af5f00   DarkOrange3
+"  6  DarkCyan     #007299 Allports           31    #0087af   DeepSkyBlue3
+"  8  DarkGray     #696969 Dove Gray         242    #6c6c6c   Grey42
+"  9  Red          #d91e18 Thunderbird       160    #d70000   Red3
+" 10  Green        #008000 Japanese Laurel    28    #008700   Green4
+" 15  White        #fefefe White              15    #ffffff   White
+" ------------------------------------------------------------------------
+
+" ========================
+" §1. Prepare color scheme
+" ========================
+
+set background=light
+highlight clear
+if exists("syntax_on")
+  syntax reset
+endif
+let g:colors_name="a11y-dark"
+let s:t_Co = exists('&t_Co') && !has('gui_running') ? (&t_Co ?? 0) : -1
+
+" =====================================================================
+" §2. Override default syntax highlighting links for specific languages
+" =====================================================================
+
+" Link the following highlight groups to the basic groups defined in §3.
+
+" ------------------------------
+" §2.1. HTML, Markdown, and YAML
+" ------------------------------
+
+" Black
+hi! link htmlTag Normal
+hi! link markdownYamlHead Normal
+hi! link yamlDocumentStart Normal
+hi! link yamlFlowIndicator Normal
+hi! link yamlKeyValueDelimiter Normal
+" Brown
+hi! link yamlBlockMappingKey Constant
+hi! link yamlFlowString Constant
+" DarkCyan
+hi! link markdownCodeBlock Statement
+hi! link markdownCodeDelimiter Statement
+
+" ---------
+" §2.2. CSS
+" ---------
+
+" DarkGray
+hi! link cssBraces Comment
+
+" ----------------
+" §2.3. JavaScript
+" ----------------
+
+" Brown
+hi! link javaScriptConditional Constant
+hi! link javaScriptLabel Constant
+hi! link javaScriptNumber Constant
+hi! link javaScriptSpecial Constant
+hi! link javaScriptStatement Constant
+" Red
+hi! link javaScriptNull Identifier
+" DarkCyan
+hi! link javaScriptConstant Statement
+" DarkGray
+hi! link javaScriptBraces Comment
+hi! link javaScriptEmbed Comment
+hi! link javaScriptParens Comment
+" Green
+hi! link javaScriptOperator Special
+hi! link javaScriptReserved Special
+hi! link javaScriptStringS Special
+hi! link javaScriptStringT Special
+
+" ------------------------------
+" §2.4 Link Vim highlight groups
+" ------------------------------
+
+" Brown
+hi! link NonText Constant
+hi! link Type Constant
+" DarkGray
+hi! link LineNr Comment
+" Red
+hi! link CursorLineNr Identifier
+hi! link PreProc Identifier
+" Green
+hi! link EndOfBuffer Special
+" Other highlight groups
+hi! link ColorColumn Visual
+hi! link CurSearch Search
+hi! link Folded Ignore
+hi! link MatchParen Visual
+hi! link Pmenu Ignore
+hi! link PmenuSel Search
+hi! link SpellBad ErrorMsg
+hi! link TabLine Ignore
+hi! link WildMenu Search
+hi! link vimHiKeyError ErrorMsg
+
+" ========================================================
+" §3. Set basic color scheme for different editions of Vim
+" ========================================================
+
+" --------------------------
+" §3.1 gVim highlight groups
+" --------------------------
+
+" Define an array of hexadecimal codes to override the 16 basic ANSI colors.
+if (has('termguicolors') && &termguicolors) || has('gui_running')
+  let g:terminal_ansi_colors = ['#545454', '#007299', '#008000', '#aa5d00', '#d91e18', '#dcc6e0', '#aa5d00', '#696969', '#696969', '#007299', '#008000', '#007299', '#d91e18', '#dcc6e0', '#aa5d00', '#fefefe']
+endif
+
+" Black
+hi Normal guifg=#545454 guibg=#fefefe gui=NONE
+" Brown
+hi Constant guifg=#aa5d00 guibg=#fefefe gui=NONE
+" DarkCyan
+hi Statement guifg=#007299 guibg=#fefefe gui=NONE
+" DarkGray
+hi Comment guifg=#696969 guibg=#fefefe gui=NONE
+" Red
+hi Identifier guifg=#d91e18 guibg=#fefefe gui=NONE
+" Green
+hi Special guifg=#008000 guibg=#fefefe gui=NONE
+" Other highlight groups
+hi ErrorMsg guifg=#fefefe guibg=#d91e18 gui=bold
+hi Ignore guifg=#fefefe guibg=#696969 gui=NONE
+hi Search guifg=#fefefe guibg=#007299 gui=bold
+hi Title guifg=NONE guibg=NONE gui=bold
+hi Todo guifg=#fefefe guibg=#008000 gui=bold
+hi Underlined guifg=NONE guibg=NONE gui=underline
+hi Visual guifg=NONE guibg=NONE gui=reverse
+
+" -------------------------------------------------------
+" §3.2. Vim highlight groups for 256-color Xterm consoles
+" -------------------------------------------------------
+
+" Xterm colors are available to most modern terminal emulators.
+if s:t_Co >= 256
+  " Black
+  hi Normal ctermbg=15 ctermfg=240 cterm=NONE
+  " Brown
+  hi Constant ctermfg=130 ctermbg=15 cterm=NONE
+  " DarkCyan
+  hi Statement ctermfg=31 ctermbg=15 cterm=NONE
+  " DarkGray
+  hi Comment ctermfg=242 ctermbg=15 cterm=NONE
+  " Red
+  hi Identifier ctermfg=160 ctermbg=15 cterm=NONE
+  " Green
+  hi Special ctermfg=28 ctermbg=15 cterm=NONE
+  " Other highlight groups
+  hi ErrorMsg ctermfg=15 ctermbg=160 cterm=bold
+  hi Ignore ctermfg=15 ctermbg=242 cterm=NONE
+  hi Search ctermfg=15 ctermbg=31 cterm=bold
+  hi Title ctermfg=NONE ctermbg=NONE cterm=bold
+  hi Todo ctermfg=15 ctermbg=28 cterm=bold
+  hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline
+  hi Visual ctermfg=NONE ctermbg=NONE cterm=reverse
+  unlet s:t_Co
+  finish
+endif
+
+" -----------------------------------------------------
+" §3.3. Vim highlight groups for 16-color ANSI consoles
+" -----------------------------------------------------
+
+" ANSI colors are available to most legacy terminal emulators.
+if s:t_Co >= 16
+  " Black
+  hi Normal ctermfg=Black ctermbg=White  cterm=NONE
+  " Brown
+  hi Constant ctermfg=Brown ctermbg=White cterm=NONE
+  hi Type ctermfg=Brown ctermbg=White cterm=NONE
+  " DarkCyan
+  hi Statement ctermfg=DarkCyan ctermbg=White cterm=NONE
+  " DarkGray
+  hi Comment ctermfg=DarkGray ctermbg=White cterm=NONE
+  " Red
+  hi Identifier ctermfg=Red ctermbg=White cterm=NONE
+  " Green
+  hi Special ctermfg=Green ctermbg=White cterm=NONE
+  " Other highlight groups
+  hi ErrorMsg ctermfg=White ctermbg=Red cterm=bold
+  hi Ignore ctermfg=White ctermbg=DarkGray cterm=NONE
+  hi Search ctermfg=White ctermbg=DarkCyan cterm=bold
+  hi Title ctermfg=NONE ctermbg=NONE cterm=bold
+  hi Todo ctermfg=White ctermbg=Green cterm=bold
+  hi Underlined ctermfg=NONE ctermbg=NONE cterm=underline
+  hi Visual ctermfg=NONE ctermbg=NONE cterm=reverse
+  unlet s:t_Co
+  finish
+endif


### PR DESCRIPTION
I modeled these color scheme files after the ones in the [Vim repo](https://www.github.com/vim/colorschemes). At the same time, I tried to simplify Vim’s list of [highlight groups](https://vimdoc.sourceforge.net/htmldoc/syntax.html#highlight-groups), focusing on HTML, CSS, JavaScript, and the ones Vim typically uses for web development.

This pull request does not include definitions for every highlight group available in Vim. That seemed outside the scope of an initial pull request. It does, however, account for the bulk of those highlight groups, primarily by [linking](https://vimdoc.sourceforge.net/htmldoc/syntax.html#:highlight-link) to one of Vim’s preferred [group names](https://vimdoc.sourceforge.net/htmldoc/syntax.html#group-name).

Because different editions of Vim support different color sets, I also tried to mimic the CSS definitions in the [a11y `/dist/highlight` directory](https://github.com/ericwbailey/a11y-syntax-highlighting/blob/main/dist/highlight/a11y-dark.css) as much as possible. For example, most modern terminals use the [256 Xterm colors](https://vim.fandom.com/wiki/Xterm256_color_names_for_console_Vim). Other terminals only have the [16 ANSI colors](https://vimdoc.sourceforge.net/htmldoc/syntax.html#gui-colors). This pull request does not include blocks for 8-color or single-color terminals.

I also added some inline comments, including a table with the different HEX, Xterm, and ANSI codes in play. Rather than listing the highlight groups in ROYGBIV order, I followed the Xterm/ANSI numbers. Then, I alphabetized the highlight groups under each color subhead.

There’s definitely room for expansion to these theme files. But this first pull request should be publishable.