### PR TITLE
Update highlight.js package in `tests/`

### DIFF
--- a/test/highlight/a11y-dark-on-light-light-on-dark.html
+++ b/test/highlight/a11y-dark-on-light-light-on-dark.html
@@ -4,15 +4,16 @@
 	<meta charset="UTF-8">
 	<title>a11y-dark-on-light-light-on-dark theme for Highlight.js</title>
 	<link rel="stylesheet" href="../../dist/highlight/a11y-dark-on-light-light-on-dark.css">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-	<script>hljs.initHighlightingOnLoad();</script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+	<script>hljs.highlightAll();</script>
 
 	<style>
 		body {
 			background-color: #fefefe;
 			color: #2b2b2b;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #2b2b2b;
 				color: #fefefe;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}

--- a/test/highlight/a11y-dark.html
+++ b/test/highlight/a11y-dark.html
@@ -4,15 +4,16 @@
 	<meta charset="UTF-8">
 	<title>a11y-dark theme for Highlight.js</title>
 	<link rel="stylesheet" href="../../dist/highlight/a11y-dark.css">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-	<script>hljs.initHighlightingOnLoad();</script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+	<script>hljs.highlightAll();</script>
 
 	<style>
 		body {
 			background-color: #fefefe;
 			color: #2b2b2b;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #2b2b2b;
 				color: #fefefe;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}

--- a/test/highlight/a11y-light-on-light-dark-on-dark.html
+++ b/test/highlight/a11y-light-on-light-dark-on-dark.html
@@ -4,15 +4,16 @@
 	<meta charset="UTF-8">
 	<title>a11y-light-on-light-dark-on-dark theme for Highlight.js</title>
 	<link rel="stylesheet" href="../../dist/highlight/a11y-light-on-light-dark-on-dark.css">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-	<script>hljs.initHighlightingOnLoad();</script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+	<script>hljs.highlightAll();</script>
 
 	<style>
 		body {
 			background-color: #2b2b2b;
 			color: #fefefe;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #fefefe;
 				color: #2b2b2b;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}

--- a/test/highlight/a11y-light.html
+++ b/test/highlight/a11y-light.html
@@ -4,15 +4,16 @@
 	<meta charset="UTF-8">
 	<title>a11y-light theme for Highlight.js</title>
 	<link rel="stylesheet" href="../../dist/highlight/a11y-light.css">
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.12.0/highlight.min.js"></script>
-	<script>hljs.initHighlightingOnLoad();</script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/11.9.0/highlight.min.js"></script>
+	<script>hljs.highlightAll();</script>
 
 	<style>
 		body {
 			background-color: #2b2b2b;
 			color: #fefefe;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #fefefe;
 				color: #2b2b2b;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}

--- a/test/prism/a11y-dark-on-light-light-on-dark.html
+++ b/test/prism/a11y-dark-on-light-light-on-dark.html
@@ -11,7 +11,8 @@
 			background-color: #fefefe;
 			color: #2b2b2b;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #2b2b2b;
 				color: #fefefe;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}

--- a/test/prism/a11y-dark.html
+++ b/test/prism/a11y-dark.html
@@ -11,7 +11,8 @@
 			background-color: #fefefe;
 			color: #2b2b2b;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #2b2b2b;
 				color: #fefefe;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}

--- a/test/prism/a11y-light-on-light-dark-on-dark.html
+++ b/test/prism/a11y-light-on-light-dark-on-dark.html
@@ -11,7 +11,8 @@
 			background-color: #2b2b2b;
 			color: #fefefe;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #fefefe;
 				color: #2b2b2b;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}

--- a/test/prism/a11y-light.html
+++ b/test/prism/a11y-light.html
@@ -11,7 +11,8 @@
 			background-color: #2b2b2b;
 			color: #fefefe;
 		}
-		a {
+		a,
+		a:visited {
 			color: #2e67d3;
 		}
 		pre {
@@ -23,7 +24,8 @@
 				background-color: #fefefe;
 				color: #2b2b2b;
 			}
-			a {
+			a,
+			a:visited {
 				color: #e1f3fe;
 			}
 		}


### PR DESCRIPTION
This PR updates the highlight.js package in `tests/` to point to the current stable version. It also provides styling for visited links for the tests, to keep them perceivable when the OS color mode is changed.